### PR TITLE
DM-5169 Make S3 uploads work with Fastly CDN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
 - pip install -r requirements.txt
 - pip install -e .
-script: py.test
+script: py.test --flake8 --cov=ltdmason
 env:
   # See README for information on variables needed for testing
   # - LTD_MASON_TEST_AWS_ID

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Unit tests
 
 Developers can run unit tests via `pytest <http://pytest.org>`_::
 
-   py.test
+   py.test  --flake8 --cov=ltdmason
 
 To run a full suite of AWS S3 integration tests, you'll need AWS credentials and an S3 bucket to test in.
 Configure the tests to use these by setting the following environment variables:

--- a/ltdmason/cli.py
+++ b/ltdmason/cli.py
@@ -3,7 +3,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 from builtins import *  # NOQA
 from future.standard_library import install_aliases
-install_aliases()
+install_aliases()  # NOQA
 
 import os
 import argparse

--- a/ltdmason/manifest.py
+++ b/ltdmason/manifest.py
@@ -9,7 +9,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 from builtins import *  # NOQA
 from future.standard_library import install_aliases
-install_aliases()
+install_aliases()  # NOQA
 
 from urllib.parse import urlparse
 import os

--- a/ltdmason/product.py
+++ b/ltdmason/product.py
@@ -5,7 +5,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 from builtins import *  # NOQA
 from future.standard_library import install_aliases
-install_aliases()
+install_aliases()  # NOQA
 
 import os
 import logging

--- a/ltdmason/s3upload.py
+++ b/ltdmason/s3upload.py
@@ -7,6 +7,7 @@ install_aliases()
 
 import os
 import logging
+import mimetypes
 
 import boto3
 
@@ -124,6 +125,9 @@ def _upload_file(local_path, bucket_path, bucket,
                  metadata=None, acl=None, cache_control=None):
     """Upload a file to the S3 bucket.
 
+    This function uses the mimetypes module to guess and then set the
+    Content-Type and Encoding-Type headers.
+
     Parameters
     ----------
     local_path : str
@@ -150,6 +154,15 @@ def _upload_file(local_path, bucket_path, bucket,
         extra_args['Metadata'] = metadata
     if cache_control is not None:
         extra_args['CacheControl'] = cache_control
+
+    # guess_type returns None if it cannot detect a type
+    content_type, content_encoding = mimetypes.guess_type(local_path,
+                                                          strict=False)
+    if content_type is not None:
+        extra_args['ContentType'] = content_type
+    if content_encoding is not None:
+        extra_args['EncodingType'] = content_encoding
+
     log.debug(str(extra_args))
 
     obj = bucket.Object(bucket_path)

--- a/ltdmason/s3upload.py
+++ b/ltdmason/s3upload.py
@@ -15,6 +15,8 @@ log.addHandler(logging.NullHandler())
 
 
 def upload(bucket_name, path_prefix, source_dir,
+           surrogate_key=None, acl='public-read',
+           cache_control_max_age=31536000,
            aws_access_key_id=None, aws_secret_access_key=None,
            aws_profile=None):
     """Upload built documentation to S3.
@@ -40,6 +42,20 @@ def upload(bucket_name, path_prefix, source_dir,
         Path of the Sphinx HTML build directory on the local file system.
         The contents of this directory are uploaded into the ``/path_prefix/``
         directory of the S3 bucket.
+    surrogate_key : str, optional
+        The surrogate key to insert in the header of all objects
+        in the ``x-amz-meta-surrogate-key`` field. This key is used to purge
+        builds from the Fastly CDN when Editions change.
+        If `None` then no header will be set.
+    acl : str, optional
+        The pre-canned AWS access control list to apply to this upload.
+        Defaults to ``'public-read'``, which allow files to be downloaded
+        over HTTP by the public. See
+        https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+        for an overview of S3's pre-canned ACL lists. Note that ACL settings
+        are not validated locally.
+    cache_control_max_age : int, optional
+        Defaults to 31536000 seconds = 1 year.
     aws_access_key_id : str, optional
         The access key for your AWS account. Also set `aws_secret_access_key`.
     aws_secret_access_key : str, optional
@@ -58,6 +74,17 @@ def upload(bucket_name, path_prefix, source_dir,
         aws_secret_access_key=aws_secret_access_key)
     s3 = session.resource('s3')
     bucket = s3.Bucket(bucket_name)
+
+    metadata = None
+    if surrogate_key is not None:
+        if metadata is None:
+            metadata = {}
+        metadata['surrogate-key'] = surrogate_key
+
+    if cache_control_max_age is not None:
+        cache_control = 'max-age={0:d}'.format(cache_control_max_age)
+    else:
+        cache_control = None
 
     manager = ObjectManager(session, bucket_name, path_prefix)
 
@@ -88,10 +115,13 @@ def upload(bucket_name, path_prefix, source_dir,
             local_path = os.path.join(rootdir, filename)
             bucket_path = os.path.join(path_prefix, bucket_root, filename)
             log.debug('Uploading to {0}'.format(bucket_path))
-            _upload_file(local_path, bucket_path, bucket)
+            _upload_file(local_path, bucket_path, bucket,
+                         metadata=metadata, acl=acl,
+                         cache_control=cache_control)
 
 
-def _upload_file(local_path, bucket_path, bucket):
+def _upload_file(local_path, bucket_path, bucket,
+                 metadata=None, acl=None, cache_control=None):
     """Upload a file to the S3 bucket.
 
     Parameters
@@ -103,10 +133,28 @@ def _upload_file(local_path, bucket_path, bucket):
         S3 bucket.
     bucket : `boto3` Bucket instance
         S3 bucket.
+    metadata : dict, optional
+        Header metadata values. These keys will appear in headers as
+        ``x-amz-meta-*``.
+    acl : str, optional
+        A pre-canned access control list. See
+        https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+    cache_control : str, optional
+        The cache-control header value. For example, 'max-age=31536000'.
+        ``'
     """
+    extra_args = {}
+    if acl is not None:
+        extra_args['ACL'] = acl
+    if metadata is not None:
+        extra_args['Metadata'] = metadata
+    if cache_control is not None:
+        extra_args['CacheControl'] = cache_control
+    log.debug(str(extra_args))
+
     obj = bucket.Object(bucket_path)
     # no return status from the upload_file api
-    obj.upload_file(local_path)
+    obj.upload_file(local_path, ExtraArgs=extra_args)
 
 
 class ObjectManager(object):

--- a/ltdmason/s3upload.py
+++ b/ltdmason/s3upload.py
@@ -3,7 +3,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 from builtins import *  # NOQA
 from future.standard_library import install_aliases
-install_aliases()
+install_aliases()  # NOQA
 
 import os
 import logging

--- a/ltdmason/uploader.py
+++ b/ltdmason/uploader.py
@@ -65,21 +65,20 @@ def upload_via_keeper(manifest, product,
     """
     # Register the documentation build for this product
     build_resource = _register_build(manifest, keeper_url, keeper_token)
-    build_url = build_resource['self_url']
 
     # Upload documentation site to S3
     if aws_credentials is None:
         # Fall back to using default AWS credentials the user might have set
         aws_credentials = {}
-    upload(build_info['bucket_name'],
-           build_info['bucket_root_dir'],
+    upload(build_resource['bucket_name'],
+           build_resource['bucket_root_dir'],
            product.html_dir,
            **aws_credentials)
     log.debug('Upload complete: {0}:{1}'.format(
-        build_info['bucket_name'], build_info['bucket_root_dir']))
+        build_resource['bucket_name'], build_resource['bucket_root_dir']))
 
     # Confirm upload to ltd-keeper
-    _confirm_upload(build_url, keeper_token)
+    _confirm_upload(build_resource['build_url'], keeper_token)
 
 
 def _register_build(manifest, keeper_url, keeper_token):

--- a/ltdmason/uploader.py
+++ b/ltdmason/uploader.py
@@ -3,7 +3,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 from builtins import *  # NOQA
 from future.standard_library import install_aliases
-install_aliases()
+install_aliases()  # NOQA
 
 import logging
 

--- a/ltdmason/uploader.py
+++ b/ltdmason/uploader.py
@@ -73,12 +73,15 @@ def upload_via_keeper(manifest, product,
     upload(build_resource['bucket_name'],
            build_resource['bucket_root_dir'],
            product.html_dir,
+           surrogate_key=build_resource['surrogate_key'],
+           acl='public-read',
+           cache_control_max_age=31536000,
            **aws_credentials)
     log.debug('Upload complete: {0}:{1}'.format(
         build_resource['bucket_name'], build_resource['bucket_root_dir']))
 
     # Confirm upload to ltd-keeper
-    _confirm_upload(build_resource['build_url'], keeper_token)
+    _confirm_upload(build_resource['self_url'], keeper_token)
 
 
 def _register_build(manifest, keeper_url, keeper_token):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 future==0.15.2
 pytest==2.8.7
+pytest-mock==0.11.0
 requests==2.9.1
 responses==0.5.1
 ruamel.yaml==0.10.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 future==0.15.2
 pytest==2.8.7
 pytest-mock==0.11.0
+pytest-cov==2.2.1
+pytest-flake8==0.2
 requests==2.9.1
 responses==0.5.1
 ruamel.yaml==0.10.17

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [pytest]
 norecursedirs = venv
+flake8-ignore =
+    doc/conf.py ALL
+    build/*.py ALL

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -4,7 +4,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 from builtins import *  # NOQA
 from future.standard_library import install_aliases
-install_aliases()
+install_aliases()  # NOQA
 
 import pkg_resources
 import pytest

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -8,7 +8,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 from builtins import *  # NOQA
 from future.standard_library import install_aliases
-install_aliases()
+install_aliases()  # NOQA
 
 import os
 import tempfile

--- a/tests/test_s3upload.py
+++ b/tests/test_s3upload.py
@@ -23,7 +23,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 from builtins import *  # NOQA
 from future.standard_library import install_aliases
-install_aliases()
+install_aliases()  # NOQA
 
 import os
 import shutil

--- a/tests/test_s3upload.py
+++ b/tests/test_s3upload.py
@@ -82,11 +82,21 @@ def test_s3upload(request):
 
     _create_test_files(temp_dir, paths)
 
+    surrogate_key = 'test-surrogate-key'
+    cache_control_max_age = 3600
     s3upload.upload(bucket_name,
                     temp_bucket_dir,
                     temp_dir,
+                    surrogate_key=surrogate_key,
+                    cache_control_max_age=cache_control_max_age,
                     **aws_credentials)
+
     _test_objects_exist(session, bucket_name, temp_bucket_dir, paths)
+
+    expected_headers = {
+        'x-amz-meta-surrogate-key': surrogate_key,
+        'Cache-Control': 'max-age={0:d}'.format(cache_control_max_age)}
+    _test_headers(session, bucket_name, temp_bucket_dir, expected_headers)
 
     # Remove some files (on filesystem and in path manifest)
     shutil.rmtree(os.path.join(temp_dir, 'dir1'))
@@ -143,6 +153,27 @@ def _test_objects_exist(session, bucket_name, bucket_root, file_list):
         if not found:
             log.error('{0} not found in bucket'.format(bucket_path))
             assert False
+
+
+def _test_headers(session, bucket_name, bucket_root, expected_headers):
+    """Generically test that header key-value pairs in `expected_headers`
+    actually are served by S3.
+    """
+    s3 = session.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+
+    # see http://stackoverflow.com/a/34698521 for making object URLs
+    bucket_location = s3.meta.client.get_bucket_location(Bucket=bucket_name)
+
+    for obj in bucket.objects.filter(Prefix=bucket_root):
+        guess, _ = mimetypes.guess_type(obj.key)
+        object_url = "https://s3-{0}.amazonaws.com/{1}/{2}".format(
+            bucket_location['LocationConstraint'],
+            bucket_name,
+            obj.key)
+        r = requests.head(object_url)
+        for key, expected_value in expected_headers.items():
+            assert r.headers[key] == expected_value
 
 
 def _clean_bucket(session, bucket_name, root_path):

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,11 +1,16 @@
 """Tests for the ltdmason/uploader module."""
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import responses
 import pkg_resources
 import pytest
 
 from ltdmason.manifest import Manifest
-from ltdmason.uploader import _register_build, _confirm_upload, KeeperError
+from ltdmason.uploader import (_register_build, _confirm_upload, KeeperError,
+                               upload_via_keeper)
 
 
 @pytest.fixture
@@ -30,6 +35,7 @@ def test_register_build_ok(demo_manifest):
         "product_url": "http://localhost:5000/products/lsst_apps",
         "self_url": "http://localhost:5000/builds/1",
         "slug": "b1",
+        "surrogate_key": "35d7a50a1d1b40ab9e7a56cd169f356e",
         "uploaded": False}
     responses.add(
         responses.POST,
@@ -108,3 +114,54 @@ def test_confirm_upload_failed():
         _confirm_upload('http://localhost:5000/builds/1', 'token')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == url
+
+
+def test_upload_via_keeper(demo_manifest, mocker):
+    """Test upload_via_keeper.
+
+    The goal is to ensure that it
+
+    1. registers a build
+    2. Calls upload with the right attributes
+    3. Confirms the upload
+    """
+    build_resource = {
+        "bucket_name": "an-s3-bucket",
+        "bucket_root_dir": "lsst_apps/builds/b1",
+        "date_created": "2016-03-01T10:21:27.583795Z",
+        "date_ended": None,
+        "git_refs": ["master"],
+        "github_requester": "jonathansick",
+        "product_url": "http://localhost:5000/products/lsst_apps",
+        "self_url": "http://localhost:5000/builds/1",
+        "slug": "b1",
+        "surrogate_key": "35d7a50a1d1b40ab9e7a56cd169f356e",
+        "uploaded": False}
+    mock_register = mocker.patch('ltdmason.uploader._register_build')
+    mock_register.return_value = build_resource
+    mock_upload = mocker.patch('ltdmason.uploader.upload')
+    mock_confirm = mocker.patch('ltdmason.uploader._confirm_upload')
+
+    mock_product = mock.MagicMock()
+    mock_product.html_dir = '_build/html'
+
+    upload_via_keeper(demo_manifest, mock_product,
+                      'https://ltd-keeper.example.org', 'token')
+
+    # Check that upload_via_keeper called the right things
+    assert mock_register.call_count == 1
+    assert mock_upload.call_count == 1
+    assert mock_confirm.call_count == 1
+
+    mock_register.assert_called_once_with(
+        demo_manifest, 'https://ltd-keeper.example.org', 'token')
+
+    mock_upload.assert_called_once_with(
+        build_resource['bucket_name'],
+        build_resource['bucket_root_dir'],
+        mock_product.html_dir,
+        surrogate_key=build_resource['surrogate_key'],
+        acl='public-read',
+        cache_control_max_age=31536000)
+
+    mock_confirm.assert_called_once_with(build_resource['self_url'], 'token')


### PR DESCRIPTION
This PR covers work on LTD Mason to integrate LSST the Docs with the Fastly CDN. In the end, we'll have a setup similar to [HashiCorp's](https://www.hashicorp.com/blog/serving-static-sites-with-fastly.html).
- [x] Be able to set surrogate-key and Cache-Control
- [x] Set Content-Type properly
- [x] Get surrogate-key from LTD Keeper API
