### PR TITLE
DM-6299: Do not attempt to set Encoding-Type header

### DIFF
--- a/ltdmason/s3upload.py
+++ b/ltdmason/s3upload.py
@@ -160,8 +160,6 @@ def _upload_file(local_path, bucket_path, bucket,
                                                           strict=False)
     if content_type is not None:
         extra_args['ContentType'] = content_type
-    if content_encoding is not None:
-        extra_args['EncodingType'] = content_encoding
 
     log.debug(str(extra_args))
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ author = 'Jonathan Sick'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 url = 'https://github.com/lsst-sqre/ltd-mason'
-version = '0.2.0'
+version = '0.2.1'
 
 
 def read(filename):


### PR DESCRIPTION
boto3 doesn't actually seem to let us set a Encoding-Type header directly, so instead we'll just drop any attempt. This came up while trying to upload a .fits.gz file (gzip encoding type).
