### PR TITLE
DM-11630: Improve logging and fix S3 'directory' listing containing `..`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Change Log
 ##########
 
+[0.2.5] - 2017-06-23
+====================
+
+Fixed
+-----
+
+- Improved the logging so that only the ``ltdmason`` logger is setup.
+  This will reduce debug logging volume from boto3.
+- ``ObjectManger.list_dirnames_in_directory`` now filters out directories named ``..``, which are artifacts of the listing process (fixes DM-11630).
+
 [0.2.4] - 2017-06-05
 ====================
 

--- a/ltdmason/s3upload.py
+++ b/ltdmason/s3upload.py
@@ -314,8 +314,13 @@ class ObjectManager(object):
             if len(dir_parts) == 1:
                 dirnames.append(dir_parts[0])
         dirnames = list(set(dirnames))
-        if '.' in dirnames:
-            dirnames.remove('.')
+
+        # Remove posix-like relative directory names that can appear
+        # in the bucket listing.
+        for filtered_dir in ('.', '..'):
+            if filtered_dir in dirnames:
+                dirnames.remove(filtered_dir)
+
         return dirnames
 
     def _create_prefix(self, dirname):

--- a/ltdmason/s3upload.py
+++ b/ltdmason/s3upload.py
@@ -96,13 +96,18 @@ def upload(bucket_name, path_prefix, source_dir,
     manager = ObjectManager(session, bucket_name, path_prefix)
 
     for (rootdir, dirnames, filenames) in os.walk(source_dir):
+        log.debug('rootdir=%r dirnames=%r filenames=%r',
+                  rootdir, dirnames, filenames)
+
         # name of root directory on S3 bucket
         bucket_root = os.path.relpath(rootdir, start=source_dir)
         if bucket_root in ('.', '/'):
             bucket_root = ''
+        log.debug('bucket_root=%r', bucket_root)
 
         # Delete bucket directories that no longer exist in source
         bucket_dirnames = manager.list_dirnames_in_directory(bucket_root)
+        log.debug('bucket_dirnames=%r', bucket_dirnames)
         for bucket_dirname in bucket_dirnames:
             if bucket_dirname not in dirnames:
                 log.debug(('Deleting bucket directory {0}'.format(
@@ -111,6 +116,7 @@ def upload(bucket_name, path_prefix, source_dir,
 
         # Delete files that no longer exist in source
         bucket_filenames = manager.list_filenames_in_directory(bucket_root)
+        log.debug('bucket_filenames=%r', bucket_dirnames)
         for bucket_filename in bucket_filenames:
             if bucket_filename not in filenames:
                 bucket_filename = os.path.join(bucket_root, bucket_filename)

--- a/ltdmason/uploader.py
+++ b/ltdmason/uploader.py
@@ -123,6 +123,8 @@ def upload_via_keeper(manifest, product,
     # Register the documentation build for this product
     build_resource = _register_build(manifest, keeper_url, keeper_token)
 
+    log.info('Registered build %r', build_resource['self_url'])
+
     # Upload documentation site to S3
     if aws_credentials is None:
         # Fall back to using default AWS credentials the user might have set
@@ -139,6 +141,8 @@ def upload_via_keeper(manifest, product,
 
     # Confirm upload to ltd-keeper
     _confirm_upload(build_resource['self_url'], keeper_token)
+
+    log.info('Finished upload for %r', build_resource['self_url'])
 
 
 def _register_build(manifest, keeper_url, keeper_token):


### PR DESCRIPTION
- Stop using `logging.basicConfig` and instead setup the `ltdmason` logger specifically. This let me avoid setting up debug messages from packages like boto3.
- Fix a bug where the `ObjectManager.list_dirnames_in_directory` could return `..` as a directory name. We were already filtering `.`, so this PR adds `..` to that filtering. Without this fix, ltd-mason was trying to find an delete a directory called `..` before uploading.